### PR TITLE
fix: improve error message for empty-session note access

### DIFF
--- a/lib/notes.py
+++ b/lib/notes.py
@@ -75,7 +75,9 @@ def add_note_to_session(session_id: str, note: str) -> int:
 def edit_note_in_session(session_id: str, index: int, new_text: str) -> str:
     """
     Edit a note by 1-based index. Returns the old note text.
-    Raises IndexError if index is out of range.
+
+    Raises IndexError if the session has no notes, or if index is out of
+    range (1-based, inclusive).
     """
     load_notes()
 
@@ -95,7 +97,9 @@ def edit_note_in_session(session_id: str, index: int, new_text: str) -> str:
 def delete_note_from_session(session_id: str, index: int) -> str:
     """
     Delete a note by 1-based index. Returns the deleted note text.
-    Raises IndexError if index is out of range.
+
+    Raises IndexError if the session has no notes, or if index is out of
+    range (1-based, inclusive).
     """
     load_notes()
 

--- a/lib/notes.py
+++ b/lib/notes.py
@@ -80,6 +80,8 @@ def edit_note_in_session(session_id: str, index: int, new_text: str) -> str:
     load_notes()
 
     notes = _notes_cache.get(session_id, [])
+    if not notes:
+        raise IndexError("Session has no notes")
     if index < 1 or index > len(notes):
         raise IndexError(f"Note index {index} out of range (1-{len(notes)})")
 
@@ -98,6 +100,8 @@ def delete_note_from_session(session_id: str, index: int) -> str:
     load_notes()
 
     notes = _notes_cache.get(session_id, [])
+    if not notes:
+        raise IndexError("Session has no notes")
     if index < 1 or index > len(notes):
         raise IndexError(f"Note index {index} out of range (1-{len(notes)})")
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -103,11 +103,6 @@ def test_edit_note_index_too_large_raises(notes_mod):
 
 
 def test_edit_note_on_empty_session_raises(notes_mod):
-    with pytest.raises(IndexError):
-        notes_mod.edit_note_in_session("empty_sess", 1, "x")
-
-
-def test_edit_note_on_empty_session_message(notes_mod):
     with pytest.raises(IndexError, match="Session has no notes"):
         notes_mod.edit_note_in_session("empty_sess", 1, "x")
 
@@ -166,11 +161,6 @@ def test_delete_note_index_too_large_raises(notes_mod):
 
 
 def test_delete_note_on_empty_session_raises(notes_mod):
-    with pytest.raises(IndexError):
-        notes_mod.delete_note_from_session("empty_sess", 1)
-
-
-def test_delete_note_on_empty_session_message(notes_mod):
     with pytest.raises(IndexError, match="Session has no notes"):
         notes_mod.delete_note_from_session("empty_sess", 1)
 

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -107,6 +107,11 @@ def test_edit_note_on_empty_session_raises(notes_mod):
         notes_mod.edit_note_in_session("empty_sess", 1, "x")
 
 
+def test_edit_note_on_empty_session_message(notes_mod):
+    with pytest.raises(IndexError, match="Session has no notes"):
+        notes_mod.edit_note_in_session("empty_sess", 1, "x")
+
+
 def test_edit_note_persists_to_disk(notes_mod):
     notes_mod.add_note_to_session("sess1", "before")
     notes_mod.edit_note_in_session("sess1", 1, "after")
@@ -162,6 +167,11 @@ def test_delete_note_index_too_large_raises(notes_mod):
 
 def test_delete_note_on_empty_session_raises(notes_mod):
     with pytest.raises(IndexError):
+        notes_mod.delete_note_from_session("empty_sess", 1)
+
+
+def test_delete_note_on_empty_session_message(notes_mod):
+    with pytest.raises(IndexError, match="Session has no notes"):
         notes_mod.delete_note_from_session("empty_sess", 1)
 
 


### PR DESCRIPTION
Closes #4

## Summary

When editing or deleting a note on a session with no notes, the error now shows `"Session has no notes"` instead of the confusing `"out of range (1-0)"`.

## Changes

### `lib/notes.py`
- Added early check in `edit_note_in_session` for empty notes list
- Added early check in `delete_note_from_session` for empty notes list

### `tests/test_notes.py`
- `test_edit_note_on_empty_session_message` - verifies error message text
- `test_delete_note_on_empty_session_message` - verifies error message text

## Test Results

All 54 tests pass.